### PR TITLE
⬇️  Fix dry-configurable dependency issue with Wecasa

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     zoho_sign (0.1.0)
       activesupport
       addressable
-      dry-configurable (~> 0.13)
+      dry-configurable (~> 0.9)
       faraday
       faraday_middleware
       rainbow
@@ -108,6 +108,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/zoho_sign.gemspec
+++ b/zoho_sign.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "activesupport"
   spec.add_dependency "addressable"
-  spec.add_dependency "dry-configurable", "~> 0.13"
+  spec.add_dependency "dry-configurable", "~> 0.9"
   spec.add_dependency "faraday"
   spec.add_dependency "faraday_middleware"
   spec.add_dependency "rainbow"


### PR DESCRIPTION
Fixing the following issue:
```
Bundler could not find compatible versions for gem "dry-configurable":
  In snapshot (Gemfile.lock):
    dry-configurable (= 0.12.1)

  In Gemfile:
    devise-jwt was resolved to 0.8.1, which depends on
      warden-jwt_auth (~> 0.5) was resolved to 0.5.0, which depends on
        dry-auto_inject (~> 0.6) was resolved to 0.7.0, which depends on
          dry-container (>= 0.3.4) was resolved to 0.7.2, which depends on
            dry-configurable (~> 0.1, >= 0.1.3)

    devise-jwt was resolved to 0.8.1, which depends on
      warden-jwt_auth (~> 0.5) was resolved to 0.5.0, which depends on
        dry-configurable (~> 0.9)

    zoho_sign was resolved to 0.1.0, which depends on
      dry-configurable (~> 0.13)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```