### PR TITLE
🐛 Fix download adapter json response

### DIFF
--- a/lib/zoho_sign/connection.rb
+++ b/lib/zoho_sign/connection.rb
@@ -114,6 +114,8 @@ module ZohoSign
       Faraday.new(url: base_url) do |conn|
         conn.headers["Authorization"] = authorization_token if access_token?
         conn.headers["Content-Type"] = "application/x-www-form-urlencoded"
+        conn.request :retry
+        conn.response :json, content_type: /\bjson$/
         conn.response :logger if ZohoSign.config.debug
         conn.adapter Faraday.default_adapter
       end


### PR DESCRIPTION
regarding https://wecasa.slack.com/archives/C4Y908Y4V/p1636017712000200

I added the retry too, to prevent the potential HTML response we might have sometimes.