### PR TITLE
🐛 Handle HTML response when invalid token

### DIFF
--- a/lib/zoho_sign/connection.rb
+++ b/lib/zoho_sign/connection.rb
@@ -112,7 +112,7 @@ module ZohoSign
         conn.headers["Authorization"] = authorization_token if access_token?
         conn.headers["Content-Type"] = "application/x-www-form-urlencoded"
         conn.request :retry
-        conn.response :json, content_type: /\bjson$/
+        conn.response :json, parser_options: { symbolize_names: true }, content_type: /\bjson$/
         conn.response :logger if ZohoSign.config.debug
         conn.adapter Faraday.default_adapter
       end

--- a/lib/zoho_sign/connection.rb
+++ b/lib/zoho_sign/connection.rb
@@ -64,17 +64,14 @@ module ZohoSign
 
     def with_refresh
       http_response = yield
-
-      return http_response unless http_response.env.response_headers["Content-Type"].include?("application/json")
-
-      response = ZohoSign::ResponseHandler.new(http_response.body)
+      response = ZohoSign::ResponseHandler.new(http_response.body, http_response.status)
       # Try to refresh the token and try again
       if response.invalid_token_error? && refresh_token?
         log "Refreshing outdated token... #{@access_token}"
         params = ZohoSign::Auth.refresh_token(@refresh_token)
         @access_token = params[:access_token]
         http_response = yield
-        response = ZohoSign::ResponseHandler.new(http_response.body)
+        response = ZohoSign::ResponseHandler.new(http_response.body, http_response.status)
       end
 
       raise ZohoSign::Error, response.detailed_message if response.error?
@@ -101,10 +98,10 @@ module ZohoSign
     def adapter
       Faraday.new(url: base_url) do |conn|
         conn.headers["Authorization"] = authorization_token if access_token?
-        conn.headers["Content-Type"] = "application/x-www-form-urlencoded"
+        conn.headers["Content-Type"] = "application/json"
         conn.request :json
         conn.request :retry
-        conn.response :json, parser_options: { symbolize_names: true }
+        conn.response :json, parser_options: { symbolize_names: true }, content_type: /\bjson$/
         conn.response :logger if ZohoSign.config.debug
         conn.adapter Faraday.default_adapter
       end

--- a/lib/zoho_sign/response_handler.rb
+++ b/lib/zoho_sign/response_handler.rb
@@ -25,6 +25,8 @@ module ZohoSign
     end
 
     def error?
+      return false if @http_response == 200
+
       (!@http_response.nil? && @http_response != 200) ||
         @response[:status] == "error" ||
         @response[:status] == "failure"

--- a/lib/zoho_sign/response_handler.rb
+++ b/lib/zoho_sign/response_handler.rb
@@ -21,7 +21,7 @@ module ZohoSign
     def success?
       return false unless @response.is_a?(Hash)
 
-      @response[:status] == "success"
+      @http_response == 200 || @response[:status] == "success"
     end
 
     def error?

--- a/spec/webmocks/document_error.html
+++ b/spec/webmocks/document_error.html
@@ -1,0 +1,45 @@
+<html>
+
+<head>
+    <link rel=\ "stylesheet\" href=\ "https://css.zohostatic.com/sign/1409/assets/vendor.css\">
+    <link rel=\ "stylesheet\" href=\ "https://css.zohostatic.com/sign/1409/assets/style.css\">
+    <link rel=\ "stylesheet\" href=\ "https://css.zohostatic.com/sign/1409/fonts/font-styles.css\">
+    <link rel=\ "SHORTCUT ICON\" href=\ "https://css.zohostatic.com/sign/1409/images/favicon.ico\">
+    <title>Zoho Sign</title>
+    <style>
+        #close-account {
+            text-decoration: underline;
+            position: relative;
+            cursor: pointer;
+        }
+    </style>
+</head>
+
+<body class=\ "z-sign main-content\">
+    <script type=\ "text/javascript\" src=\ "https://js.zohostatic.com/sign/1409/assets/vendor.js\">
+    </script>
+    <script type=\ "text/javascript\">
+        var allow_close = 'false' === \"true\";function loadCallback(){if(allow_close){jQuery(\"#close-account\").show();//NoI18N}}function getCSRFCookie() {var csrf = getCookie(\"zscsrfcookie\"); // No I18Nreturn csrf;}function getCookie(name) {var init = document.cookie.indexOf(name + \"=\");if (init === 0){init = document.cookie.indexOf(\" \" + name + \"=\") + 1;}if (init != -1) {var userlen = name.length;var beginIndex = init + userlen;var endIndex = document.cookie.indexOf(\";\", beginIndex);if (endIndex == -1) {endIndex = document.cookie.length;}var cVal = document.cookie.substring(beginIndex + 1, endIndex);return cVal;}return null;}function closeAccount(){var postData= [];var zscsrfparam = getCSRFCookie();postData.push({name: 'zscsrfparam',//No I18Nvalue: zscsrfparam}); jQuery.ajax({url: '/api/v1/accounts/close', // No I18Ntype: 'PUT', // No I18Ndata: postData,dataType: 'json', // No I18Nasync: true,success: function (data, textStatus, jqXHR) {if (data.status == \"success\") {jQuery(\"#close-account\").removeAttr(\"onclick\");//No I18NjQuery(\"#errormsg\").hide();//No I18NjQuery(\"#close-account\").text(\"Your account has been closed\");//No I18N}}});}window.addEventListener(\"load\", function () {loadCallback();});
+    </script>
+    <div class=\ "wrapper\">
+        <div class=\ "left-slide\">
+            <div class=\ "zs-logo-container guest-side\">
+                <a href=\ "/\"><img src=\ "https://css.zohostatic.com/sign/1409/images/logo.png\">
+                    <div class=\ "logo-text\">Sign</div>
+                </a>
+            </div>
+            <header class=\ "guest-header\" style=\ "width: 1268px;\"></header>
+        </div>
+        <header class=\ "main-header\"></header>
+        <div class=\ "background-style\" style=\ "width:100%;\">
+            <div class=\ "message-body\">
+                <div class=\ "back-clr\"></div>
+                <div class=\ "error-message\"><span id=\ "errormsg\">Invalid Oauth token</span>
+                    <div id=\ "close-account\" style=\ "display:none\" onclick=\ "closeAccount()\">Close account</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
I decided to handle the error in `ResponseHandler`
I changed the params name from `params` to `response` as I thought it would make more sense now. 