### PR TITLE
🐛  Fix create document API call

### DIFF
--- a/lib/zoho_sign/connection.rb
+++ b/lib/zoho_sign/connection.rb
@@ -98,7 +98,7 @@ module ZohoSign
     def adapter
       Faraday.new(url: base_url) do |conn|
         conn.headers["Authorization"] = authorization_token if access_token?
-        conn.headers["Content-Type"] = "application/json"
+        conn.headers["Content-Type"] = "application/x-www-form-urlencoded"
         conn.request :json
         conn.request :retry
         conn.response :json, parser_options: { symbolize_names: true }, content_type: /\bjson$/

--- a/spec/zoho_sign/template_spec.rb
+++ b/spec/zoho_sign/template_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe ZohoSign::Template do
           .with(
             headers: {
               "Authorization" => "Zoho-oauthtoken Invalid Token",
-              "Content-Type" => "application/json"
+              "Content-Type" => "application/x-www-form-urlencoded"
             }
           )
           .to_return(
@@ -145,7 +145,7 @@ RSpec.describe ZohoSign::Template do
         .with(
           headers: {
             "Authorization" => /Zoho-oauthtoken .*/,
-            "Content-Type" => "application/json"
+            "Content-Type" => "application/x-www-form-urlencoded"
           }
         )
         .to_return(
@@ -202,7 +202,7 @@ RSpec.describe ZohoSign::Template do
         .with(
           headers: {
             "Authorization" => /Zoho-oauthtoken .*/,
-            "Content-Type" => "application/json"
+            "Content-Type" => "application/x-www-form-urlencoded"
           }
         )
         .to_return(

--- a/spec/zoho_sign/template_spec.rb
+++ b/spec/zoho_sign/template_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ZohoSign::Template do
         .with(
           headers: {
             "Authorization" => /Zoho-oauthtoken .*/,
-            "Content-Type" => "application/json"
+            "Content-Type" => "application/x-www-form-urlencoded"
           }
         )
         .to_return(
@@ -73,7 +73,7 @@ RSpec.describe ZohoSign::Template do
         .with(
           headers: {
             "Authorization" => "Zoho-oauthtoken #{ENV["ZOHO_SIGN_ACCESS_TOKEN"]}",
-            "Content-Type" => "application/json"
+            "Content-Type" => "application/x-www-form-urlencoded"
           }
         )
         .to_return(


### PR DESCRIPTION
Fixing the following error when callign create_document
/home/deployer/wecasa/shared/bundle/ruby/3.0.0/bundler/gems/zoho_sign-fb6a845ac4bb/lib/zoho_sign/connection.rb:77:in `with_refresh’: {:code=>9039, :error_param=>“zoho-inputstream”, :message=>“Unable to process your request”, :status=>“failure”} (ZohoSign::Error)