### PR TITLE
:sparkles: Adding support for Zoho regional domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ ZohoSign.config.update(
 params = ZohoSign::Auth.refresh_token(ENV["ZOHO_SIGN_REFRESH_TOKEN"])
 ZohoSign.config.connection = params
 ```
-
+### Configure regional domain (if applicable)
+```ruby
+ZohoSign.config.update(
+  api: {
+    auth_domain: "https://accounts.zoho.eu",
+    domain: "https://sign.zoho.eu"
+  }
+)
+```
 ### How to use `ZohoSign::Template`
 
 Find all templetes:

--- a/lib/zoho_sign.rb
+++ b/lib/zoho_sign.rb
@@ -27,6 +27,7 @@ module ZohoSign
   end
 
   setting :api do
+    setting :auth_domain, default: "https://accounts.zoho.com"
     setting :domain, default: "https://sign.zoho.com"
     setting :base_path, default: "/api/v1"
   end

--- a/lib/zoho_sign/auth.rb
+++ b/lib/zoho_sign/auth.rb
@@ -11,8 +11,6 @@ module ZohoSign
   class Auth
     extend Forwardable
 
-    AUTH_DOMAIN_PATH = "https://accounts.zoho.com"
-
     TOKEN_PATH = "/oauth/v2/token"
 
     DEFAULT_SCOPES = %w[
@@ -27,6 +25,7 @@ module ZohoSign
       @configuration = ZohoSign.config
       @access_type = access_type
       @scopes = scopes
+      @auth_domain_path = ZohoSign.config.api.auth_domain
     end
 
     def self.refresh_token(refresh_token)
@@ -57,7 +56,7 @@ module ZohoSign
     end
 
     def token_full_uri
-      Addressable::URI.join(AUTH_DOMAIN_PATH, TOKEN_PATH)
+      Addressable::URI.join(@auth_domain_path, TOKEN_PATH)
     end
 
     def self.get_token(grant_token)

--- a/lib/zoho_sign/version.rb
+++ b/lib/zoho_sign/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZohoSign
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/zoho_sign_spec.rb
+++ b/spec/zoho_sign_spec.rb
@@ -20,24 +20,21 @@ RSpec.describe ZohoSign do
         }
       )
 
-      expect(described_class.config.values)
-        .to eq(
-          {
-            debug: false,
-            oauth: {
-              client_id: "1000.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-              client_secret: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-              access_token: "2000.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-              refresh_token: "3000.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-              redirect_uri: "http://example.com"
-            },
-            connection: nil,
-            api: {
-              domain: "https://sign.zoho.com",
-              base_path: "/api/v1"
-            }
-          }
-        )
+      expect(described_class.config.debug).to be_falsey
+      expect(described_class.config.connection).to be_nil
+      expect(described_class.config.oauth.to_h).to eq({
+                                                   client_id: "1000.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                                   client_secret: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                                   access_token: "2000.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                                   refresh_token: "3000.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                                   redirect_uri: "http://example.com"
+                                                 })
+      expect(described_class.config.api.to_h).to eq({
+                                                 auth_domain: "https://accounts.zoho.com",
+                                                 domain: "https://sign.zoho.com",
+                                                 base_path: "/api/v1"
+                                               })
+
     end
   end
 end


### PR DESCRIPTION
Zoho offers regional domains and the domain for the auth and api are different. This PR offers the ability to set those domains.